### PR TITLE
fix compilation in case sensitive environments.

### DIFF
--- a/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
@@ -33,11 +33,11 @@
 
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
-#include <arduino.h>
+#include <Arduino.h>
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP.h>
 #elif defined(__MKL26Z64__)
-#include <arduino.h>
+#include <Arduino.h>
 #else
 #error Unknown architecture in aes.cpp
 #endif

--- a/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
@@ -33,11 +33,11 @@
 
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
-#include <arduino.h>
+#include <Arduino.h>
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP.h>
 #elif defined(__MKL26Z64__)
-#include <arduino.h>
+#include <Arduino.h>
 #else
 #error Unknown architecture in aes.cpp
 #endif

--- a/libraries/lmic-v1.51/src/lmic/AES-128_V10.cpp
+++ b/libraries/lmic-v1.51/src/lmic/AES-128_V10.cpp
@@ -28,7 +28,7 @@
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP.h>
 #elif defined(__MKL26Z64__)
-#include <arduino.h>
+#include <Arduino.h>
 #else
 #error Unknown architecture in aes.cpp
 #endif

--- a/libraries/lmic-v1.51/src/lmic/aes.cpp
+++ b/libraries/lmic-v1.51/src/lmic/aes.cpp
@@ -24,11 +24,11 @@
 
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
-#include <arduino.h>
+#include <Arduino.h>
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP.h>
 #elif defined(__MKL26Z64__)
-#include <arduino.h>
+#include <Arduino.h>
 #else
 #error Unknown architecture in aes.cpp
 #endif

--- a/libraries/lmic-v1.51/src/lmic/lmic.cpp
+++ b/libraries/lmic-v1.51/src/lmic/lmic.cpp
@@ -16,11 +16,11 @@
 #include "lmic.h"
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
-#include <arduino.h>
+#include <Arduino.h>
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP.h>
 #elif defined(__MKL26Z64__)
-#include <arduino.h>
+#include <Arduino.h>
 #else
 #error Unknown architecture in aes.cpp
 #endif

--- a/libraries/lmic-v1.51/src/lmic/oslmic.cpp
+++ b/libraries/lmic-v1.51/src/lmic/oslmic.cpp
@@ -12,11 +12,11 @@
 #include "lmic.h"
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
-#include <arduino.h>
+#include <Arduino.h>
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP.h>
 #elif defined(__MKL26Z64__)
-#include <arduino.h>
+#include <Arduino.h>
 #else
 #error Unknown architecture in aes.cpp
 #endif

--- a/libraries/lmic-v1.51/src/lmic/radio.cpp
+++ b/libraries/lmic-v1.51/src/lmic/radio.cpp
@@ -13,11 +13,11 @@
 #define TEST 0
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
-#include <arduino.h>
+#include <Arduino.h>
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP.h>
 #elif defined(__MKL26Z64__)
-#include <arduino.h>
+#include <Arduino.h>
 #else
 #error Unknown architecture in aes.cpp
 #endif


### PR DESCRIPTION
Some file systems like the Linux ext file system are case sensitive.
In such situation it it needed to use same case in the include
directive as the case of the headers. This commit replaces occurrences
of <arduino.h> into <Arduino.h>

Without this commit the following error is visible::
examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino:36:21: fatal error:
arduino.h: No such file or directory #include <arduino.h>

compilation terminated.
exit status 1

I won't take the credits for this  see
https://revspace.nl/LoraWanNode
