### PR TITLE
Add "category=Communication"

### DIFF
--- a/libraries/lmic-v1.51/library.properties
+++ b/libraries/lmic-v1.51/library.properties
@@ -6,3 +6,4 @@ sentence=Arduino port of LoRaWAN C-library (LMiC) v1.5 framework provided by IBM
 paragraph=Supports SX1272/SX1276 and HopeRF RFM92/RFM95 tranceivers
 url=http://www.research.ibm.com/labs/zurich/ics/lrsc/lmic.html
 architectures=avr
+category=Communication


### PR DESCRIPTION
Add "category=Communication" to library.properties to silence warning. Fixes https://github.com/things4u/LoRa-LMIC-1.51/issues/7
