### PR TITLE
msbf4_read corrupts certain Device Addresses

### DIFF
--- a/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
@@ -72,7 +72,7 @@ unsigned char AppSkey[16] =	{ 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0x
 
 // LoRaWAN end-device address (DevAddr)
 // See http://thethingsnetwork.org/wiki/AddressSpace
-static const u4_t DevAddr = 0x01010101;
+u4_t DevAddr = 0x01010101;
 
 
 // ----------------------------------------------------------------------------

--- a/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
@@ -72,9 +72,7 @@ unsigned char AppSkey[16] =	{ 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0x
 
 // LoRaWAN end-device address (DevAddr)
 // See http://thethingsnetwork.org/wiki/AddressSpace
-
-#define msbf4_read(p)   (u4_t)((u4_t)(p)[0]<<24 | (u4_t)(p)[1]<<16 | (p)[2]<<8 | (p)[3])
-unsigned char DevAddr[4] = { 0x01, 0x01, 0x01, 0x01 };
+static const u4_t DevAddr = 0x01010101;
 
 
 // ----------------------------------------------------------------------------
@@ -171,7 +169,7 @@ void setup() {
   LMIC_reset();
   // Set static session parameters. Instead of dynamically establishing a session 
   // by joining the network, precomputed session parameters are be provided.
-  LMIC_setSession (0x1, msbf4_read(DevAddr), (uint8_t*)NwkSkey, (uint8_t*)AppSkey);
+  LMIC_setSession (0x1, DevAddr, (uint8_t*)NwkSkey, (uint8_t*)AppSkey);
   // Disable data rate adaptation
   LMIC_setAdrMode(0);
   // Disable link check validation

--- a/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
@@ -71,7 +71,7 @@ unsigned char AppSkey[16] =		{ 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0
 
 // LoRaWAN end-device address (DevAddr)
 // See http://thethingsnetwork.org/wiki/AddressSpace
-static const u4_t DevAddr = 0x01010101;
+u4_t DevAddr = 0x01010101;
 
 
 // ----------------------------------------------------------------------------

--- a/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
@@ -71,9 +71,7 @@ unsigned char AppSkey[16] =		{ 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0
 
 // LoRaWAN end-device address (DevAddr)
 // See http://thethingsnetwork.org/wiki/AddressSpace
-
-#define msbf4_read(p)   (u4_t)((u4_t)(p)[0]<<24 | (u4_t)(p)[1]<<16 | (p)[2]<<8 | (p)[3])
-unsigned char DevAddr[4] = { 0x01, 0x01, 0x01, 0x01 };
+static const u4_t DevAddr = 0x01010101;
 
 
 // ----------------------------------------------------------------------------
@@ -167,7 +165,7 @@ void setup() {
   LMIC_reset();
   // Set static session parameters. Instead of dynamically establishing a session 
   // by joining the network, precomputed session parameters are be provided.
-  LMIC_setSession (0x1, msbf4_read(DevAddr), (uint8_t*)NwkSkey, (uint8_t*)AppSkey);
+  LMIC_setSession (0x1, DevAddr, (uint8_t*)NwkSkey, (uint8_t*)AppSkey);
   // Disable data rate adaptation
   LMIC_setAdrMode(0);
   // Disable link check validation

--- a/libraries/lmic-v1.51/src/lmic/Encrypt_V30.cpp
+++ b/libraries/lmic-v1.51/src/lmic/Encrypt_V30.cpp
@@ -30,6 +30,7 @@
 *****************************************************************************************
 */
 
+#include "oslmic.h"
 #include "Encrypt_V30.h"
 #include "AES-128_V10.h"
 
@@ -41,7 +42,7 @@
 
 extern unsigned char NwkSkey[16];
 extern unsigned char AppSkey[16];
-extern unsigned char DevAddr[4];
+extern u4_t DevAddr;
 
 // --------------------------------------------------------------------
 //
@@ -73,10 +74,10 @@ void Encrypt_Payload(unsigned char *Data, unsigned char Data_Length, unsigned in
 
 		Block_A[5] = Direction;
 
-		Block_A[6] = DevAddr[3];
-		Block_A[7] = DevAddr[2];
-		Block_A[8] = DevAddr[1];
-		Block_A[9] = DevAddr[0];
+		Block_A[6] = DevAddr;
+		Block_A[7] = DevAddr>>8;
+		Block_A[8] = DevAddr>>16;
+		Block_A[9] = DevAddr>>24;
 
 		Block_A[10] = (Frame_Counter & 0x00FF);
 		Block_A[11] = ((Frame_Counter >> 8) & 0x00FF);
@@ -157,10 +158,10 @@ void Calculate_MIC(unsigned char *Data, unsigned char *Final_MIC, unsigned char 
 
 	Block_B[5] = Direction;
 
-	Block_B[6] = DevAddr[3];
-	Block_B[7] = DevAddr[2];
-	Block_B[8] = DevAddr[1];
-	Block_B[9] = DevAddr[0];
+	Block_B[6] = DevAddr;
+	Block_B[7] = DevAddr>>8;
+	Block_B[8] = DevAddr>>16;
+	Block_B[9] = DevAddr>>24;
 
 	Block_B[10] = (Frame_Counter & 0x00FF);
 	Block_B[11] = ((Frame_Counter >> 8) & 0x00FF);


### PR DESCRIPTION
Just enter it directly as a u4_t. 

eg `{ 0x01, 0x58, 0xA5, 0xA2 }` would end up as `FFFFA5A2`
