### PR TITLE
Split rxtx pin into separate Receive Enable and Transmit Enable pins.

### DIFF
--- a/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/esp-lmic-v1.51-F/esp-lmic-v1.51-F.ino
@@ -107,7 +107,8 @@ static osjob_t sendjob;
 //
 lmic_pinmap pins = {
   .nss = 15,			// Connected to pin D
-  .rxtx = 2, 			// For placeholder only, Do not connected on RFM92/RFM95 
+  .rxen = 0, 			// Needed for NiceRF Lora1276. Not needed for RFM92/RFM95
+  .txen = 0, 			// Needed for NiceRF Lora1276. Not needed for RFM92/RFM95
   .rst = 0,  			// Needed on RFM92/RFM95? (probably not) D0/GPIO16
   .dio = {5, 4, 3},		// Specify pin numbers for DIO0, 1, 2
 						// connected to D5, D4, D3 

--- a/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
+++ b/libraries/lmic-v1.51/examples/nano-lmic-v1.51-F/nano-lmic-v1.51-F.ino
@@ -106,7 +106,8 @@ static osjob_t sendjob;
 //
 lmic_pinmap pins = {
   .nss = 10,			// Connected to pin D10
-  .rxtx = 0, 			// For placeholder only, Do not connected on RFM92/RFM95
+  .rxen = 0, 			// Needed for NiceRF Lora1276. Not needed for RFM92/RFM95
+  .txen = 0, 			// Needed for NiceRF Lora1276. Not needed for RFM92/RFM95
   .rst = 0,  			// Needed on RFM92/RFM95? (probably not)
   .dio = {4, 5, 7},		// Specify pin numbers for DIO0, 1, 2
 						// connected to D4, D5, D7 

--- a/libraries/lmic-v1.51/src/hal/hal.cpp
+++ b/libraries/lmic-v1.51/src/hal/hal.cpp
@@ -35,8 +35,8 @@
 
 static void hal_io_init () {
     pinMode(pins.nss, OUTPUT);
-    pinMode(pins.rxtx, OUTPUT);			// NOT used on ESP8266
-    pinMode(pins.rst, OUTPUT);
+    pinMode(pins.rxen, OUTPUT);
+    pinMode(pins.txen, OUTPUT);
     pinMode(pins.dio[0], INPUT);
     pinMode(pins.dio[1], INPUT);
     pinMode(pins.dio[2], INPUT);
@@ -44,7 +44,13 @@ static void hal_io_init () {
 
 // val == 1  => tx 1
 void hal_pin_rxtx (u1_t val) {
-    digitalWrite(pins.rxtx, val);
+	if (val == 1) {
+		digitalWrite(pins.txen, 1);
+		digitalWrite(pins.rxen, 0);
+	} else {
+		digitalWrite(pins.txen, 0);
+		digitalWrite(pins.rxen, 1);
+	}
 }
 
 // set radio RST pin to given value (or keep floating!)

--- a/libraries/lmic-v1.51/src/hal/hal.h
+++ b/libraries/lmic-v1.51/src/hal/hal.h
@@ -14,7 +14,8 @@ static const int NUM_DIO = 3;
 
 struct lmic_pinmap {
     u1_t nss;
-    u1_t rxtx;					// No used by ESP8266 and Aduino
+    u1_t rxen; // Recieve enable pin, needed for some SX1276 modules (eg NiceRF Lora1276)
+    u1_t txen; // Transmit enable pin, needed for some SX1276 modules (eg NiceRF Lora1276)	
     u1_t rst;
     u1_t dio[NUM_DIO];			// No all a needed bij ESP8266 and Arduino
 };


### PR DESCRIPTION
The NiceRF Lora1276 has separate Receive Enable and Transmit Enable pins. This splits the currently unused rxtx pin into rxen and txen. 

Those needing a single pin should only use the txen pin as this follows the behaviour of the old rxtx pin.
